### PR TITLE
Add pluralize as non-closing statement

### DIFF
--- a/src/jinja.ts
+++ b/src/jinja.ts
@@ -41,4 +41,5 @@ export const nonClosingStatements = [
 	"import",
 	"from",
 	"extends",
+	"pluralize",
 ];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -136,7 +136,7 @@ export const parse: Parser<Node>["parse"] = (text) => {
 						}
 
 						throw new Error(
-							`Closung statement "${statement}" doesn't match Opening Statement "${start.content}".`
+							`Closing statement "${statement}" doesn't match Opening Statement "${start.content}".`
 						);
 					}
 				}


### PR DESCRIPTION
The jinja i18n extension supports statements like this:

```jinja
{% trans count=list|length %}
There is {{ count }} {{ name }} object.
{% pluralize %}
There are {{ count }} {{ name }} objects.
{% endtrans %}
```

However, the plugin would fail with the following error:

```
[error] test.html: Error: Closung statement "endtrans" doesn't match Opening Statement "pluralize".
[error]     at Object.parse (node_modules/prettier-plugin-jinja-template/lib/parser.js:93:31)
[error]     at Object.parse (node_modules/prettier/index.js:7515:23)
[error]     at coreFormat (node_modules/prettier/index.js:8829:18)
[error]     at formatWithCursor2 (node_modules/prettier/index.js:9021:18)
[error]     at Object.formatWithCursor (node_modules/prettier/index.js:38168:12)
[error]     at format (node_modules/prettier/cli.js:15017:24)
[error]     at formatFiles2 (node_modules/prettier/cli.js:15131:22)
[error]     at async main (node_modules/prettier/cli.js:15356:5)
[error]     at async Object.run (node_modules/prettier/cli.js:15303:5)
```

This PR adds `pluralize` to the list of non-closing statements. It also fixes the 'closung' typo in the error message.