### PR TITLE
Dedent multiline content

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,7 +1,7 @@
-import { AstPath, Printer, Doc, Options } from "prettier";
+import { AstPath, Doc, Options, Printer } from "prettier";
 import { builders, utils } from "prettier/doc";
-import { Placeholder, Node, Expression, Statement, Block } from "./jinja";
 import { extendedOptions } from "./index";
+import { Block, Expression, Node, Placeholder, Statement } from "./jinja";
 
 const NOT_FOUND = -1;
 
@@ -195,10 +195,24 @@ export const embed: Printer<Node>["embed"] = () => {
 };
 
 const getMultilineGroup = (content: String): builders.Group => {
+	// Dedent the content by the minimum indentation of any non-blank lines.
+	const lines = content.split("\n");
+	const minIndent = Math.min(
+		...lines
+			.slice(1) // can't be the first line
+			.filter((line) => line.trim())
+			.map((line) => line.search(/\S/)),
+	);
+
 	return builders.group(
-		content.split("\n").map((line, i) => {
-			return [builders.hardline, line.trim()];
-		}),
+		lines.map((line, i) => [
+			builders.hardline,
+			i === 0
+				? line.trim() // don't dedent the first line
+				: line.trim()
+					? line.slice(minIndent).trimEnd()
+					: "",
+		]),
 	);
 };
 

--- a/test/cases/expression_multiline/expected.html
+++ b/test/cases/expression_multiline/expected.html
@@ -1,9 +1,9 @@
 <div>
   {{
     {
-    'dict': 'of',
-    'key': 'and',
-    'value': 'pairs'
+      'dict': 'of',
+      'key': 'and',
+      'value': 'pairs'
     }
   }}
 </div>

--- a/test/cases/expression_multiline/input.html
+++ b/test/cases/expression_multiline/input.html
@@ -1,9 +1,9 @@
 <div>
 {{
-  {
-    'dict': 'of',
-      'key': 'and',  
-'value': 'pairs'
-  }
+        {
+          'dict': 'of',
+          'key': 'and',  
+          'value': 'pairs'
+        }
 }}
 </div>

--- a/test/cases/statement_long/expected.html
+++ b/test/cases/statement_long/expected.html
@@ -1,9 +1,10 @@
 <ul>
   {%
     for href, caption in [
-    ('index.html', 'Index'),
-    ('about.html', 'About'),
-    ('downloads.html', 'Downloads')]
+      ('index.html', 'Index'),
+      ('about.html', 'About'),
+      ('downloads.html', 'Downloads')
+    ]
   %}
     <li><a href="{{ href }}">{{ caption }}</a></li>
   {% endfor %}

--- a/test/cases/statement_long/input.html
+++ b/test/cases/statement_long/input.html
@@ -1,8 +1,9 @@
 <ul>
 {% for href, caption in [
-('index.html', 'Index'),
-    ('about.html', 'About'),  
-  ('downloads.html', 'Downloads')]
+  ('index.html', 'Index'),
+  ('about.html', 'About'),  
+  ('downloads.html', 'Downloads')
+]
 %}
 <li><a href="{{ href }}">{{ caption }}</a></li>
 {% endfor %}


### PR DESCRIPTION
This pull request dedents multiline content in the code by the minimum indentation of any non-blank lines, fixing #13.

It's "dumb" in a way, since it just respects the original indentation of that multiline, but it's better than just flattening it.

In the example given there,
```
{% set dict = {
    "item": "value",
    "list": [
      "value",
      "value",
      "value",
    ],
    "item": "value",
} %}
```

Would be rewritten to:
```
{%
  set dict = {
      "item": "value",
      "list": [
        "value",
        "value",
        "value",
      ],
      "item": "value",
  }
%}
```