### PR TITLE
feat: consider "jinja-html" in valid vscode lang id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export const languages: SupportLanguage[] = [
 		name: "JinjaTemplate",
 		parsers: [PLUGIN_KEY],
 		extensions: [".jinja", ".jinja2", ".j2", ".html"],
-		vscodeLanguageIds: ["jinja"],
+		vscodeLanguageIds: ["jinja", "jinja-html"],
 	},
 ];
 


### PR DESCRIPTION
Hi 👋🏻 

I'm using https://github.com/samuelcolvin/jinjahtml-vscode vscode extension for highlighting the jinja template however when I use this plugin it doesn't allow prettier to format the code. This is because that highlighter uses jinja-html and it was missing in updated file.

I hope this change is valid.

Thanks for this plugin 🙏🏻 