### PR TITLE
support prettier range ignore via jinja comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Using range ignores is the best way to tell prettier to igone part of files. Mos
 <!-- prettier-ignore-end -->
 ```
 
+Or using Jinja comments:
+```jinja
+{# prettier-ignore-start #}
+  <script>
+    window.someData = {{ data | safe }}
+  </script>
+{# prettier-ignore-end #}
+
+{# prettier-ignore-start #}
+  <style>
+    :root { --accent-color: {{ theme_accent_color }} }
+  </style>
+{# prettier-ignore-end #}
+```
+
 ## Options
 
 This Plugin provides additional options:

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,7 +11,7 @@ import {
 const NOT_FOUND = -1;
 
 const regex =
-	/(?<node>{{(?<startDelimiterEx>[-+]?)\s*(?<expression>'([^']|\\')*'|"([^"]|\\")*"|[\S\s]*?)\s*(?<endDelimiterEx>[-+]?)}}|{%(?<startDelimiter>[-+]?)\s*(?<statement>(?<keyword>\w+)('([^']|\\')*'|"([^"]|\\")*"|[\S\s])*?)\s*(?<endDelimiter>[-+]?)%}|(?<comment>{#[\S\s]*?#})|(?<scriptBlock><(script)((?!<)[\s\S])*>((?!<\/script)[\s\S])*?{{[\s\S]*?<\/(script)>)|(?<styleBlock><(style)((?!<)[\s\S])*>((?!<\/style)[\s\S])*?{{[\s\S]*?<\/(style)>)|(?<ignoreBlock><!-- prettier-ignore-start -->[\s\S]*<!-- prettier-ignore-end -->))/;
+	/(?<node>{{(?<startDelimiterEx>[-+]?)\s*(?<expression>'([^']|\\')*'|"([^"]|\\")*"|[\S\s]*?)\s*(?<endDelimiterEx>[-+]?)}}|{%(?<startDelimiter>[-+]?)\s*(?<statement>(?<keyword>\w+)('([^']|\\')*'|"([^"]|\\")*"|[\S\s])*?)\s*(?<endDelimiter>[-+]?)%}|(?<ignoreBlock>(?:<!-- prettier-ignore-start -->|{# prettier-ignore-start #})[\s\S]*(?:<!-- prettier-ignore-end -->|{# prettier-ignore-end #}))|(?<comment>{#[\S\s]*?#})|(?<scriptBlock><(script)((?!<)[\s\S])*>((?!<\/script)[\s\S])*?{{[\s\S]*?<\/(script)>)|(?<styleBlock><(style)((?!<)[\s\S])*>((?!<\/style)[\s\S])*?{{[\s\S]*?<\/(style)>))/;
 
 export const parse: Parser<Node>["parse"] = (text) => {
 	const statementStack: Statement[] = [];

--- a/test/cases/ignore_jinja/expected.html
+++ b/test/cases/ignore_jinja/expected.html
@@ -1,0 +1,34 @@
+<html>
+  <script>
+    {
+      {
+        js;
+      }
+    }
+  </script>
+
+  <style>
+    /* {{ css }} */
+  </style>
+
+  {# prettier-ignore-start #}
+			<ul>
+			{%for item in seq%}
+			<li>
+			{{item}}
+			</li>
+			{%endfor%}
+			</ul>
+  {# prettier-ignore-end #}
+
+  <!-- prettier-ignore -->
+  <div         class="{{class}}"       >hello world</div            >
+  <div class="{{ class }}">hello world</div>
+
+  {% if foo %}
+    <p>
+      <!-- prettier-ignore -->
+      {{item}}
+    </p>
+  {% endif %}
+</html>

--- a/test/cases/ignore_jinja/input.html
+++ b/test/cases/ignore_jinja/input.html
@@ -1,0 +1,30 @@
+<html>
+<script>
+{{js}}
+</script>
+
+<style>
+/* {{ css }} */
+</style>
+
+  {# prettier-ignore-start #}
+			<ul>
+			{%for item in seq%}
+			<li>
+			{{item}}
+			</li>
+			{%endfor%}
+			</ul>
+  {# prettier-ignore-end #}
+
+  <!-- prettier-ignore -->
+  <div         class="{{class}}"       >hello world</div            >
+  <div         class="{{class}}"       >hello world</div            >
+
+{%if foo%}
+<p>
+<!-- prettier-ignore -->
+{{item}}
+</p>
+{%endif%}
+</html>


### PR DESCRIPTION
I spent a while trying to get `{# prettier-ignore #}` next-AST-node ignores to work too but gave up, I'm not really sure how the Jinja parser here and the builtin HTML parser of prettier are supposed to interact in that case. (I was trying to add a `hasPrettierIgnore` method to the printer...)

Anyway, these range ignore tags seem to work ok.

