### PR TITLE
remove quoteAttributes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To format basic .html files, you'll have to override the used parser inside your
 }
 ```
 
-Run it on all html files in your project:
+Run it on all HTML files in your project:
 ```bash
 npx prettier --write **/*.html
 ```
@@ -43,7 +43,7 @@ npx prettier --plugin=prettier-plugin-jinja-template --parser=jinja-template --w
 
 ### Ignoring Code
 
-Using range ignores is the best way to tell prettier to igone part of files. Most of the time this is necessary for Jinja tags inside `script` or `style` tags:
+Using range ignores is the best way to tell prettier to ignore part of files. Most of the time this is necessary for Jinja tags inside `script` or `style` tags:
 
 ```html
 <!-- prettier-ignore-start -->
@@ -74,24 +74,3 @@ Or using Jinja comments:
 {# prettier-ignore-end #}
 ```
 
-## Options
-
-This Plugin provides additional options:
-
-### Quote Attributes
-
-Surrounds the value of html attributes with quotes. This option was introduced to support [JinjaX](https://jinjax.scaletti.dev/) syntax.
-
-`true` - Example:
-```js
-<Paginator items="{products}" />
-```
-
-`false` - Example:
-```js
-<Paginator items={products} />
-```
-
-| Default | CLI Override            | API Override              |
-| ------- | ----------------------- | ------------------------- |
-| `true`  | `--no-quote-attributes` | `quoteAttributes: <bool>` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,7 @@
 import { Node } from "./jinja";
 import { parse } from "./parser";
 import { print, embed, getVisitorKeys } from "./printer";
-import {
-	Parser,
-	Printer,
-	SupportLanguage,
-	SupportOptions,
-	ParserOptions,
-} from "prettier";
+import { Parser, Printer, SupportLanguage } from "prettier";
 
 const PLUGIN_KEY = "jinja-template";
 
@@ -34,18 +28,5 @@ export const printers = {
 		print,
 		embed,
 		getVisitorKeys,
-	},
-};
-
-export type extendedOptions = ParserOptions<Node> & {
-	quoteAttributes: boolean;
-};
-
-export const options: SupportOptions = {
-	quoteAttributes: {
-		type: "boolean",
-		category: PLUGIN_KEY,
-		default: true,
-		description: "Surrounds the value of html attributes with quotes.",
 	},
 };

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,6 +1,5 @@
 import { AstPath, Doc, Options, Printer } from "prettier";
 import { builders, utils } from "prettier/doc";
-import { extendedOptions } from "./index";
 import { Block, Expression, Node, Placeholder, Statement } from "./jinja";
 
 const NOT_FOUND = -1;
@@ -121,17 +120,9 @@ export const embed: Printer<Node>["embed"] = () => {
 				if (content in node.nodes) {
 					doc = content;
 				} else {
-					/**
-					 * The lwc parser is the same as the "html" parser,
-					 * but also formats LWC-specific syntax for unquoted template attributes.
-					 */
-					const parser = (options as extendedOptions).quoteAttributes
-						? "html"
-						: "lwc";
-
 					doc = await textToDoc(content, {
 						...options,
-						parser,
+						parser: "html",
 					});
 				}
 

--- a/test/cases/jinjaX/config.json
+++ b/test/cases/jinjaX/config.json
@@ -1,3 +1,0 @@
-{
-    "quoteAttributes": false
-}

--- a/test/cases/jinjaX/expected.html
+++ b/test/cases/jinjaX/expected.html
@@ -1,1 +1,0 @@
-<Paginator items={products} />

--- a/test/cases/jinjaX/input.html
+++ b/test/cases/jinjaX/input.html
@@ -1,1 +1,0 @@
-<Paginator items={products} />


### PR DESCRIPTION
Since jinjaX v0.4 the attribute syntax changed and the workaround with not quoting attributes is no longer needed.