### PR TITLE
Preserve empty lines before set statements

### DIFF
--- a/src/jinja.ts
+++ b/src/jinja.ts
@@ -3,9 +3,8 @@ export const Placeholder = {
 	endToken: "~#",
 };
 
-export interface Node {
+interface BaseNode {
 	id: string;
-	type: "root" | "expression" | "statement" | "block" | "comment" | "ignore";
 	content: string;
 	preNewLines: number;
 	originalText: string;
@@ -14,26 +13,46 @@ export interface Node {
 	nodes: { [id: string]: Node };
 }
 
+export interface RootNode extends BaseNode {
+	type: "root";
+}
+
 type DelimiterChr = "" | "-" | "+";
 export type Delimiter = {
 	start: DelimiterChr;
 	end: DelimiterChr;
 };
 
-export interface Expression extends Node {
+export interface ExpressionNode extends BaseNode {
 	type: "expression";
 	delimiter: Delimiter;
 }
 
-export interface Statement extends Node {
+export interface StatementNode extends BaseNode {
 	type: "statement";
 	keyword: string;
 	delimiter: Delimiter;
 }
 
-export interface Block extends Node {
+export interface BlockNode extends BaseNode {
 	type: "block";
-	start: Statement;
-	end: Statement;
+	start: StatementNode;
+	end: StatementNode;
 	containsNewLines: boolean;
 }
+
+export interface CommentNode extends BaseNode {
+	type: "comment";
+}
+
+export interface IgnoreNode extends BaseNode {
+	type: "ignore";
+}
+
+export type Node =
+	| RootNode
+	| ExpressionNode
+	| StatementNode
+	| BlockNode
+	| CommentNode
+	| IgnoreNode;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -83,6 +83,11 @@ const printStatement = (node: Statement): builders.Doc => {
 	) {
 		return [builders.dedent(builders.hardline), statemnt, builders.hardline];
 	}
+
+	if (node.keyword === "set" && node.preNewLines > 1) {
+		return builders.group([builders.trim, builders.hardline, statemnt]);
+	}
+
 	return statemnt;
 };
 

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -164,7 +164,7 @@ export const embed: Printer<Node>["embed"] = () => {
 							res.push(currentDoc.slice(lastEnd, start));
 						}
 
-						const p = currentDoc.slice(start, end + 1) as string;
+						const p = currentDoc.slice(start, end + 1);
 
 						if (ignoreDoc) {
 							res.push(node.nodes[p].originalText);
@@ -220,9 +220,9 @@ const getMultilineGroup = (content: String): builders.Group => {
 
 const splitAtElse = (node: Node): string[] => {
 	const elseNodes = Object.values(node.nodes).filter(
-		(n) =>
+		(n): n is StatementNode =>
 			n.type === "statement" &&
-			["else", "elif"].includes((n as StatementNode).keyword) &&
+			["else", "elif"].includes(n.keyword) &&
 			node.content.search(n.id) !== NOT_FOUND,
 	);
 	if (!elseNodes.length) {
@@ -238,7 +238,7 @@ const splitAtElse = (node: Node): string[] => {
  * occuring in a string.
  */
 export const findPlaceholders = (text: string): [number, number][] => {
-	const res = [];
+	const res: [number, number][] = [];
 	let i = 0;
 
 	while (true) {
@@ -249,10 +249,7 @@ export const findPlaceholders = (text: string): [number, number][] => {
 			.search(Placeholder.endToken);
 		if (end === NOT_FOUND) break;
 
-		res.push([
-			start + i,
-			end + start + i + Placeholder.startToken.length + 1,
-		] as [number, number]);
+		res.push([start + i, end + start + i + Placeholder.startToken.length + 1]);
 		i += start + Placeholder.startToken.length;
 	}
 	return res;
@@ -260,8 +257,9 @@ export const findPlaceholders = (text: string): [number, number][] => {
 
 export const surroundingBlock = (node: Node): BlockNode | undefined => {
 	return Object.values(node.nodes).find(
-		(n) => n.type === "block" && n.content.search(node.id) !== NOT_FOUND,
-	) as BlockNode;
+		(n): n is BlockNode =>
+			n.type === "block" && n.content.search(node.id) !== NOT_FOUND,
+	);
 };
 
 const buildBlock = (

--- a/test/cases/newline_between/expected.html
+++ b/test/cases/newline_between/expected.html
@@ -14,9 +14,12 @@
 {{ title }}
 
 {# content #}
+
+{% set welcome_message = "Welcome to my awesome homepage." %}
+
 {% block content %}
   <h1>Index</h1>
-  <p class="important">Welcome to my awesome homepage.</p>
+  <p class="important">{{ welcome_message }}</p>
 {% endblock %}
 
 <div></div>

--- a/test/cases/newline_between/input.html
+++ b/test/cases/newline_between/input.html
@@ -16,10 +16,15 @@
     
 	
 {# content #}
+
+
+{% set welcome_message = "Welcome to my awesome homepage." %}
+
+
 {% block content %}
     <h1>Index</h1>
     <p class="important">
-      Welcome to my awesome homepage.
+      {{welcome_message}}
     </p>
   
 {% endblock %}


### PR DESCRIPTION
Currently, the line breaks preceding a set statement are removed, but they should be replaced with a hard line. This PR fixes that, but it also removes most of the type casts in the code; for example, I have refactored the `Node` type to use a discriminated union in order to eliminate type casts for the nodes.